### PR TITLE
ZERO/ZEROS/ZEROES

### DIFF
--- a/TypeCobol.Test/Compiler/CodeElements/ArithmeticStatementTester.cs
+++ b/TypeCobol.Test/Compiler/CodeElements/ArithmeticStatementTester.cs
@@ -27,7 +27,7 @@ namespace TypeCobol.Test.Compiler.CodeElements
                 StringBuilder s = new StringBuilder();
                 Dump(s, add);
                 string dump = s.ToString();
-                if (c >= rpn.Length) errors.AppendFormat("RPN number {} not provided.", c);
+                if (c >= rpn.Length) errors.AppendFormat("RPN number {0} not provided.", c);
                 else if (dump != rpn[c]) errors.AppendFormat("{0}: \"{1}\", expected \"{2}\"\n", c, dump, rpn[c]);
                 c++;
             }

--- a/TypeCobol.Test/Compiler/Parser/Samples/Statements/ADDCodeElements.cbl
+++ b/TypeCobol.Test/Compiler/Parser/Samples/Statements/ADDCodeElements.cbl
@@ -15,6 +15,7 @@ ADD
 ADD 1 TO x.
 ADD 1 2 TO toto.
 ADD 1 2 3 TO x toto.
+ADD 1 0 1 0 1 0 to x.
 * SYNTAX ERRORS
 * literals not allowed as 2nd operand
 ADD 1 TO 1.
@@ -39,6 +40,8 @@ ADD 1 TO m GIVING x.
 ADD 1 TO m GIVING x y.
 ADD a 1 TO 2 GIVING x.
 ADD a b ab TO 1 GIVING x toto.
+ADD 0 TO 0 GIVING x.
+ADD 1 0 1 0 1 TO 0 GIVING x.
 * SYNTAX ERRORS
 * only 1 identifier as 2nd operand
 *ADD a b ab TO x y xy GIVING titi toto.

--- a/TypeCobol.Test/Compiler/Parser/TestCodeElements.cs
+++ b/TypeCobol.Test/Compiler/Parser/TestCodeElements.cs
@@ -112,6 +112,7 @@ namespace TypeCobol.Test.Compiler.Parser
                 "x = 1 x +",
                 "toto = 1 2 + toto +",
                 "x = 1 2 + 3 + x +, toto = 1 2 + 3 + toto +",
+                "x = 1 0 + 1 + 0 + 1 + 0 + x +",
                 "", "", "", "", "", // literals not allowed as 2nd operand
                 //format 2
                 "x = a m +",
@@ -121,6 +122,8 @@ namespace TypeCobol.Test.Compiler.Parser
                 "x = 1 m +, y = 1 m +",
                 "x = a 1 + 2 +",
                 "x = a b + ab + 1 +, toto = a b + ab + 1 +",
+                "x = 0 0 +",
+                "x = 1 0 + 1 + 0 + 1 + 0 +",
                 // format 3
                 "x = a x +",
                 "x = a x +",

--- a/TypeCobol/Compiler/CodeElements/Expressions/SyntaxNumber.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/SyntaxNumber.cs
@@ -3,7 +3,6 @@ using TypeCobol.Compiler.Scanner;
 
 namespace TypeCobol.Compiler.CodeElements
 {
-
     /// <summary>
     /// Integer, Decimal or Floating Point value defined by a single Token in the Cobol syntax
     /// </summary>
@@ -18,68 +17,27 @@ namespace TypeCobol.Compiler.CodeElements
         /// Token defining the number value
         /// </summary>
         public Token Token { get; private set; }
-    }
-
-    /// <summary>
-    /// Integer value defined by a single Token in the Cobol syntax
-    /// </summary>
-    public class SyntaxInteger : SyntaxNumber
-    {
-        public SyntaxInteger(Token token)
-            : base(token)
-        { }
 
         /// <summary>
-        /// Integer value defined by the Token
+        /// Numeric value defined by the Token
         /// </summary>
-        public long Value
+        public object Value
         {
             get
             {
                 if (Token.TokenType == TokenType.IntegerLiteral)
                 {
                     return ((IntegerLiteralValue)Token.LiteralValue).Number;
-                }
-                else
-                {
-                    throw new InvalidOperationException("An integer value can not be defined by a token of type : " + Token.TokenType);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Debug string
-        /// </summary>
-        public override string ToString()
-        {
-            return Value.ToString();
-        }
-    }
-
-    /// <summary>
-    /// Decimal value defined by a single Token in the Cobol syntax
-    /// </summary>
-    public class SyntaxDecimal : SyntaxNumber
-    {
-        public SyntaxDecimal(Token token)
-            : base(token)
-        { }
-
-        /// <summary>
-        /// Integer value defined by the Token
-        /// </summary>
-        public double Value
-        {
-            get
-            {
+                } else
                 if (Token.TokenType == TokenType.DecimalLiteral)
                 {
                     return ((DecimalLiteralValue)Token.LiteralValue).Number;
-                }
-                else
+                } else
+                if (Token.TokenType == TokenType.FloatingPointLiteral)
                 {
-                    throw new InvalidOperationException("A decimal value can not be defined by a token of type : " + Token.TokenType);
+                    return ((FloatingPointLiteralValue)Token.LiteralValue).Number;
                 }
+                throw new InvalidOperationException("No numeric value can be defined by a token of type : " + Token.TokenType);
             }
         }
 
@@ -93,38 +51,29 @@ namespace TypeCobol.Compiler.CodeElements
     }
 
     /// <summary>
-    /// Decimal value defined by a single Token in the Cobol syntax
+    /// Zero defined by a single Token in the Cobol syntax
     /// </summary>
-    public class SyntaxFloat : SyntaxNumber
+    public class SyntaxZero : SyntaxNumber
     {
-        public SyntaxFloat(Token token)
-            : base(token)
-        { }
+        public SyntaxZero(Token token) : base(token) { }
 
         /// <summary>
-        /// Integer value defined by the Token
+        /// 0 as a long
         /// </summary>
-        public double Value
+        public long Value
         {
             get
             {
-                if (Token.TokenType == TokenType.FloatingPointLiteral)
-                {
-                    return ((DecimalLiteralValue)Token.LiteralValue).Number;
-                }
-                else
-                {
-                    throw new InvalidOperationException("A floating point value can not be defined by a token of type : " + Token.TokenType);
-                }
+                return 0;
             }
         }
 
         /// <summary>
-        /// Debug string
+        /// Debug string "0"
         /// </summary>
         public override string ToString()
         {
-            return Value.ToString();
+            return "0";
         }
     }
 }

--- a/TypeCobol/Compiler/CodeElements/Expressions/SyntaxNumber.cs
+++ b/TypeCobol/Compiler/CodeElements/Expressions/SyntaxNumber.cs
@@ -36,6 +36,12 @@ namespace TypeCobol.Compiler.CodeElements
                 if (Token.TokenType == TokenType.FloatingPointLiteral)
                 {
                     return ((FloatingPointLiteralValue)Token.LiteralValue).Number;
+                } else
+                if (Token.TokenType == TokenType.ZERO
+                 || Token.TokenType == TokenType.ZEROS
+                 || Token.TokenType == TokenType.ZEROES)
+                {
+                    return 0;
                 }
                 throw new InvalidOperationException("No numeric value can be defined by a token of type : " + Token.TokenType);
             }
@@ -47,33 +53,6 @@ namespace TypeCobol.Compiler.CodeElements
         public override string ToString()
         {
             return Value.ToString();
-        }
-    }
-
-    /// <summary>
-    /// Zero defined by a single Token in the Cobol syntax
-    /// </summary>
-    public class SyntaxZero : SyntaxNumber
-    {
-        public SyntaxZero(Token token) : base(token) { }
-
-        /// <summary>
-        /// 0 as a long
-        /// </summary>
-        public long Value
-        {
-            get
-            {
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Debug string "0"
-        /// </summary>
-        public override string ToString()
-        {
-            return "0";
         }
     }
 }

--- a/TypeCobol/Compiler/CodeElements/Header/SectionHeader.cs
+++ b/TypeCobol/Compiler/CodeElements/Header/SectionHeader.cs
@@ -30,7 +30,7 @@ namespace TypeCobol.Compiler.CodeElements
         /// Segments with a priority-number of 50 through 99 are independent
         /// segments.
         /// </summary>
-        public SyntaxInteger PriorityNumber { get; set; }
+        public SyntaxNumber PriorityNumber { get; set; }
 
         /// <summary>
         /// Debug string

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
@@ -304,7 +304,7 @@ namespace TypeCobol.Compiler.Parser
             Token priorityNumber = ParseTreeUtils.GetFirstToken(context.priorityNumber());
             if (priorityNumber != null)
             {
-                sectionHeader.PriorityNumber = new SyntaxInteger(priorityNumber);
+                sectionHeader.PriorityNumber = new SyntaxNumber(priorityNumber);
             }
             
             CodeElement = sectionHeader;
@@ -439,22 +439,27 @@ namespace TypeCobol.Compiler.Parser
         {
             if (context.IntegerLiteral() != null)
             {
-                Token token = ParseTreeUtils.GetTokenFromTerminalNode(context.IntegerLiteral());
-                return new SyntaxInteger(token);
+                return new SyntaxNumber(ParseTreeUtils.GetTokenFromTerminalNode(context.IntegerLiteral()));
             }
             if (context.DecimalLiteral() != null)
             {
-                Token token = ParseTreeUtils.GetTokenFromTerminalNode(context.DecimalLiteral());
-                return new SyntaxDecimal(token);
+                return new SyntaxNumber(ParseTreeUtils.GetTokenFromTerminalNode(context.DecimalLiteral()));
             }
             if (context.FloatingPointLiteral() != null)
             {
-                Token token = ParseTreeUtils.GetTokenFromTerminalNode(context.FloatingPointLiteral());
-                return new SyntaxFloat(token);
+                return new SyntaxNumber(ParseTreeUtils.GetTokenFromTerminalNode(context.FloatingPointLiteral()));
             }
-            if (context.ZERO() != null || context.ZEROS() != null || context.ZEROES() != null)
+            if (context.ZERO() != null)
             {
-                throw new System.Exception("TODO: How do I represent a zero ?");
+                return new SyntaxZero(ParseTreeUtils.GetTokenFromTerminalNode(context.ZERO()));
+            }
+            if (context.ZEROS() != null)
+            {
+                return new SyntaxZero(ParseTreeUtils.GetTokenFromTerminalNode(context.ZEROS()));
+            }
+            if (context.ZEROES() != null)
+            {
+                return new SyntaxZero(ParseTreeUtils.GetTokenFromTerminalNode(context.ZEROES()));
             }
             throw new System.Exception("This is not a number!");
         }

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
@@ -451,15 +451,15 @@ namespace TypeCobol.Compiler.Parser
             }
             if (context.ZERO() != null)
             {
-                return new SyntaxZero(ParseTreeUtils.GetTokenFromTerminalNode(context.ZERO()));
+                return new SyntaxNumber(ParseTreeUtils.GetTokenFromTerminalNode(context.ZERO()));
             }
             if (context.ZEROS() != null)
             {
-                return new SyntaxZero(ParseTreeUtils.GetTokenFromTerminalNode(context.ZEROS()));
+                return new SyntaxNumber(ParseTreeUtils.GetTokenFromTerminalNode(context.ZEROS()));
             }
             if (context.ZEROES() != null)
             {
-                return new SyntaxZero(ParseTreeUtils.GetTokenFromTerminalNode(context.ZEROES()));
+                return new SyntaxNumber(ParseTreeUtils.GetTokenFromTerminalNode(context.ZEROES()));
             }
             throw new System.Exception("This is not a number!");
         }


### PR DESCRIPTION
Seen in [ef784cb] (https://github.com/wiztigers/TypeCobol/commit/ef784cbb11d0026bb5a091df689aa78bd00181b0)
Traced in https://github.com/wiztigers/TypeCobol/issues/5

Manage ZERO/ZEROS/ZEROES Tokens as (long) SyntaxNumber for ADD Statements.