### PR TITLE
Numeric Literals only in the grammar's ADD rule

### DIFF
--- a/TypeCobol.Grammar/Grammars/Cobol/CobolCodeElements.g4
+++ b/TypeCobol.Grammar/Grammars/Cobol/CobolCodeElements.g4
@@ -4366,31 +4366,8 @@ acceptStatement:
 
 // p298: ADD statement
 // The ADD statement sums two or more numeric operands and stores the result.
-// p298: Format 1: ADD statement
-//addStatement:
-//                ADD (identifier | literal)+ TO (identifier ROUNDED?)+
-//                (ON? SIZE ERROR imperativeStatement)?
-//                (NOT ON? SIZE ERROR imperativeStatement)?
-//                END_ADD?;
-// All identifiers or literals that precede the keyword TO are added together, and this sum is added to and stored in identifier-2. 
-// This process is repeated for each successive occurrence of identifier-2 in the left-to-right order in which identifier-2 is specified.
-//
-// p299: Format 2: ADD statement with GIVING phrase
-//addStatement:
-//                ADD (identifier | literal)+ TO (identifier | literal)
-//                GIVING (identifier ROUNDED?)+
-//                (ON? SIZE ERROR imperativeStatement)?
-//                (NOT ON? SIZE ERROR imperativeStatement)?
-//                END_ADD?;
-// The values of the operands that precede the word GIVING are added together, and the sum is stored as the new value of each data item referenced by identifier-3.
-//
-// p299: Format 3: ADD statement with CORRESPONDING phrase
-//addStatement:
-//                ADD (CORRESPONDING | CORR) identifier TO identifier ROUNDED?
-//                (ON? SIZE ERROR imperativeStatement)?
-//                (NOT ON? SIZE ERROR imperativeStatement)?
-//                END_ADD?;
-// Elementary data items within identifier-1 are added to and stored in the corresponding elementary items within identifier-2.
+addStatement:
+		addStatementFormat3 | addStatementFormat2 | addStatementFormat1;
 //
 // For all formats:
 // identifier-1, identifier-2 
@@ -4402,43 +4379,47 @@ acceptStatement:
 // When the ARITH(COMPAT) compiler option is in effect, the composite of operands can contain a maximum of 30 digits.
 // When the ARITH(EXTEND) compiler option is in effect, the composite of operands can contain a maximum of 31 digits. 
 // For more information, see “Arithmetic statement operands” on page 284 and the details on arithmetic intermediate results in Appendix A. Intermediate results and arithmetic precision in the Enterprise COBOL Programming Guide. 
-// ROUNDED phrase
-// For formats 1, 2, and 3, see “ROUNDED phrase” on page 282. 
-// SIZE ERROR phrases
-// For formats 1, 2, and 3, see “SIZE ERROR phrases” on page 283. 
-// CORRESPONDING phrase (format 3)
-// See “CORRESPONDING phrase” on page 281. 
-// END-ADD phrase
-// This explicit scope terminator serves to delimit the scope of the ADD statement. END-ADD permits a conditional ADD statement to be nested in another conditional statement. END-ADD can also be used with an imperative ADD statement.
-// For more information, see “Delimited scope statements” on page 280.
+		
+// p298: Format 1: ADD statement
+// All identifiers or literals that precede the keyword TO are added together, and this sum is added to and stored in identifier-2. 
+// This process is repeated for each successive occurrence of identifier-2 in the left-to-right order in which identifier-2 is specified.
+addStatementFormat1:
+		ADD identifierOrNumericLiteral+ TO identifierRounded+;
 
-addStatement:
-		addStatementFormat3 | addStatementFormat2 | addStatementFormat1;
+// p299: Format 2: ADD statement with GIVING phrase
+// The values of the operands that precede the word GIVING are added together, and the sum is stored as the new value of each data item referenced by identifier-3.
+addStatementFormat2:
+		ADD identifierOrNumericLiteral+ TO identifierOrNumericLiteral GIVING identifierRounded+;
 
+// p299: Format 3: ADD statement with CORRESPONDING phrase
+// Elementary data items within identifier-1 are added to and stored in the corresponding elementary items within identifier-2.
 addStatementFormat3:
 		ADD corresponding identifier TO identifierRounded;
 
-addStatementFormat2:
-		ADD identifierOrLiteral+ TO identifierOrLiteral GIVING identifierRounded+;
-
-addStatementFormat1:
-		ADD identifierOrLiteral+ TO identifierRounded+;
-
-identifierOrLiteral:
-		identifier | literal;
-
+identifierOrNumericLiteral:
+		identifier | numericLiteral;
+		
+// ROUNDED phrase
+// For formats 1, 2, and 3, see “ROUNDED phrase” on page 282. 
 identifierRounded:
 		identifier ROUNDED?;
-
+		
+// CORRESPONDING phrase (format 3)
+// See “CORRESPONDING phrase” on page 281. 
 corresponding:
 		CORRESPONDING | CORR;
-
+		
+// SIZE ERROR phrases
+// For formats 1, 2, and 3, see “SIZE ERROR phrases” on page 283. 
 onSizeErrorCondition:
 		ON? SIZE ERROR;
 
 notOnSizeErrorCondition:
 		NOT ON? SIZE ERROR;
-
+		
+// END-ADD phrase
+// This explicit scope terminator serves to delimit the scope of the ADD statement. END-ADD permits a conditional ADD statement to be nested in another conditional statement. END-ADD can also be used with an imperative ADD statement.
+// For more information, see “Delimited scope statements” on page 280.
 addStatementEnd:
 		END_ADD;
 

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
@@ -459,7 +459,7 @@ namespace TypeCobol.Compiler.Parser
             throw new System.Exception("This is not a number!");
         }
 
-        private Expression createLeftOperand(IReadOnlyList<CobolCodeElementsParser.IdentifierOrLiteralContext> operands)
+        private Expression createLeftOperand(IReadOnlyList<CobolCodeElementsParser.IdentifierOrNumericLiteralContext> operands)
         {
             Expression left = null;
             foreach (var operand in operands) {
@@ -469,15 +469,9 @@ namespace TypeCobol.Compiler.Parser
                     tail = CreateIdentifier(operand.identifier());
                 }
                 else
-                if (operand.literal() != null)
+                if (operand.numericLiteral() != null)
                 {
-                    SyntaxNumber number = null;
-                    if (operand.literal().numericLiteral() != null)
-                    {
-                        // TODO this will throw an exception if strings are added
-                        number = CreateNumberLiteral(operand.literal().numericLiteral());
-                        tail = new Number(number);
-                    }
+                    tail = new Number(CreateNumberLiteral(operand.numericLiteral()));
                 }
                 if (tail == null) continue;
                 if (left == null)
@@ -499,10 +493,10 @@ namespace TypeCobol.Compiler.Parser
             AddStatement statement = new AddStatement();
 
             Expression left = null;
-            if (context.identifierOrLiteral() != null)
+            if (context.identifierOrNumericLiteral() != null)
             {
                 // create the "left" operand of this addition
-                left = createLeftOperand(context.identifierOrLiteral());
+                left = createLeftOperand(context.identifierOrNumericLiteral());
             }
             if (left != null && context.identifierRounded() != null)
             {
@@ -525,11 +519,11 @@ namespace TypeCobol.Compiler.Parser
             AddStatement statement = new AddStatement();
 
             Expression operation = null;
-            if (context.identifierOrLiteral() != null)
+            if (context.identifierOrNumericLiteral() != null)
             {
                 // here we add all abc..yz in "ADD ab..y TO z" without distinction between
                 // what is after the ADD and before the TO, and what is after the TO
-                operation = createLeftOperand(context.identifierOrLiteral());
+                operation = createLeftOperand(context.identifierOrNumericLiteral());
             }
             if (operation != null && context.identifierRounded() != null)
             {


### PR DESCRIPTION
Seen in [ef784cb] (https://github.com/wiztigers/TypeCobol/commit/ef784cbb11d0026bb5a091df689aa78bd00181b0)
Traced in https://github.com/wiztigers/TypeCobol/issues/6

Grammar now says explicitely that only 'numeric' literals can be in ADD statement.