### PR TITLE
Use SymbolReferences

### DIFF
--- a/TypeCobol.Test/Compiler/CodeElements/ArithmeticStatementTester.cs
+++ b/TypeCobol.Test/Compiler/CodeElements/ArithmeticStatementTester.cs
@@ -11,7 +11,7 @@ namespace TypeCobol.Test.Compiler.CodeElements
         {
             foreach (var pair in statement.affectations)
             {
-                output.AppendFormat("{0} = {1}, ", pair.Key.Text, pair.Value.ToString());
+                output.AppendFormat("{0} = {1}, ", pair.Key.Symbol.NameToken.Text, pair.Value.ToString());
             }
             if (statement.affectations.Count > 0) output.Length -= 2;
         }
@@ -27,7 +27,7 @@ namespace TypeCobol.Test.Compiler.CodeElements
                 StringBuilder s = new StringBuilder();
                 Dump(s, add);
                 string dump = s.ToString();
-                if (c >= rpn.Length) errors.AppendFormat("RPN number {} not provided.", c);
+                if (c >= rpn.Length) errors.AppendFormat("RPN number {0} not provided.", c);
                 else if (dump != rpn[c]) errors.AppendFormat("{0}: \"{1}\", expected \"{2}\"\n", c, dump, rpn[c]);
                 c++;
             }

--- a/TypeCobol/Compiler/CodeElements/Statement/AddStatement.cs
+++ b/TypeCobol/Compiler/CodeElements/Statement/AddStatement.cs
@@ -8,8 +8,8 @@ namespace TypeCobol.Compiler.CodeElements
     {
         public AddStatement() : base(CodeElementType.AddStatement)
         {
-            affectations = new Dictionary<Token, Expression>();
+            affectations = new Dictionary<SymbolReference<DataName>, Expression>();
         }
-        public Dictionary<Token, Expression> affectations { get; set; }
+        public Dictionary<SymbolReference<DataName>, Expression> affectations { get; set; }
     }
 }

--- a/TypeCobol/Compiler/CodeElements/Symbols/DataName.cs
+++ b/TypeCobol/Compiler/CodeElements/Symbols/DataName.cs
@@ -4,7 +4,7 @@ using TypeCobol.Compiler.Scanner;
 namespace TypeCobol.Compiler.CodeElements
 {
     /// <summary>
-    /// Declared int the DATA DIVISION.
+    /// Declared in the DATA DIVISION.
     /// Identifies a data item used in the program.
     /// </summary>
     public class DataName : Symbol

--- a/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
+++ b/TypeCobol/Compiler/Parser/CodeElementBuilder.cs
@@ -513,8 +513,8 @@ namespace TypeCobol.Compiler.Parser
                     Identifier right = CreateIdentifier(operand.identifier());
                     right.rounded = operand.ROUNDED() != null;
                     Expression operation = new Addition(left, right);
-                    Token token = ParseTreeUtils.GetFirstToken(operand.identifier());//TODO SymbolRef
-                    statement.affectations.Add(token, operation);//TODO SymbolRef
+                    Token token = ParseTreeUtils.GetFirstToken(operand.identifier());
+                    statement.affectations.Add(new SymbolReference<DataName>(new DataName(token)), operation);
                 }
             }
             CodeElement = statement;
@@ -537,8 +537,8 @@ namespace TypeCobol.Compiler.Parser
                 {
                     Identifier right = CreateIdentifier(operand.identifier());
                     right.rounded = operand.ROUNDED() != null;
-                    Token token = ParseTreeUtils.GetFirstToken(operand.identifier());//TODO SymbolRef
-                    statement.affectations.Add(token, operation);//TODO SymbolRef
+                    Token token = ParseTreeUtils.GetFirstToken(operand.identifier());
+                    statement.affectations.Add(new SymbolReference<DataName>(new DataName(token)), operation);
                 }
             }
 
@@ -553,7 +553,7 @@ namespace TypeCobol.Compiler.Parser
             Token token = ParseTreeUtils.GetFirstToken(context.identifierRounded());
             Expression right = new Identifier(token, context.identifierRounded().ROUNDED() != null);
             Expression operation = new Addition(left, right);
-            statement.affectations.Add(token, operation);
+            statement.affectations.Add(new SymbolReference<DataName>(new DataName(token)), operation);
 
             CodeElement = statement;
         }


### PR DESCRIPTION
Seen in https://github.com/wiztigers/TypeCobol/commit/c79e1fc97997523c03b30b316647332e95f5d759 and https://github.com/wiztigers/TypeCobol/commit/4a563167a9dbdb8e35f72a6ff0fa3c8f4e84be69
Traced in [issue 3] (https://github.com/wiztigers/TypeCobol/issues/3)

Dictionnary AddStatement.affectations now use proper SymbolReferences instead of Tokens.